### PR TITLE
Fix shell completion installation for commands with spaces

### DIFF
--- a/src/django_typer/shells/__init__.py
+++ b/src/django_typer/shells/__init__.py
@@ -79,7 +79,7 @@ class DjangoTyperShellCompleter(ShellComplete):
         **kwargs,
     ):
         # we don't always need the initialization parameters during completion
-        self.prog_name = prog_name
+        self.prog_name = prog_name.replace(" ", "_")
         if command:
             self.command = command
         if command_str is not None:


### PR DESCRIPTION
When using `shellcompletion install --manage-script="command with spaces"`, the completion script is created with spaces in the filename (e.g., `_command with spaces`), which causes issues with shell completion functionality.

## Reproduction Steps

```bash
# When running the command with spaces in the manage-script parameter
python manage.py shellcompletion install --manage-script="just manage"       
# Output:
Installed autocompletion for zsh @ /Users/aliymnx/.zfunc/_just_manage

# When checking the file system, spaces exist in the filename
ls -la ~/.zfunc/                                                      
-rw-r--r--@  1 aliymnx  staff  2529 Mar 15 03:17 _just_manage