### PR TITLE
Simplify GitHub Actions via setup-python allow-prereleases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       actions: write
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.3']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         django-version:
           - '3.2' # LTS April 2024
           - '4.2' # LTS April 2026
@@ -57,13 +57,13 @@ jobs:
             django-version: '5.0'
           - python-version: '3.9'
             django-version: '5.2'
-          - python-version: '3.14.0-rc.3'
+          - python-version: '3.14'
             django-version: '3.2'
-          - python-version: '3.14.0-rc.3'
+          - python-version: '3.14'
             django-version: '4.2'
-          - python-version: '3.14.0-rc.3'
+          - python-version: '3.14'
             django-version: '5.0'
-          - python-version: '3.14.0-rc.3'
+          - python-version: '3.14'
             django-version: '5.1'
     env:
       COVERAGE_FILE: py${{ matrix.python-version }}-linux-dj${{ matrix.django-version }}.coverage
@@ -78,6 +78,7 @@ jobs:
       id: sp
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: install-emacs-linux
       if: ${{ github.event.inputs.debug == 'true' }}
       run: |


### PR DESCRIPTION
Do not hardcode the prerelease version and automatically roll over to the production release when it is published.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases