### PR TITLE
Reduce shellcompletion CI test times

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ on:
     # Every Sunday at 9:00 AM Los Angeles time.
     # GitHub cron is UTC; 09:00 PT == 17:00 UTC (PST).
     - cron: "0 17 * * 0"
+    # Runs at the start of every hour, UTC - check for race conditions/hangs
+    - cron: "0 * * * *"
 
 env:
   ENABLE_CI_ONLY_TESTS: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ on:
     # Every Sunday at 9:00 AM Los Angeles time.
     # GitHub cron is UTC; 09:00 PT == 17:00 UTC (PST).
     - cron: "0 17 * * 0"
-    # Runs at the start of every hour, UTC - check for race conditions/hangs
-    - cron: "0 * * * *"
 
 env:
   ENABLE_CI_ONLY_TESTS: "1"

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -4,6 +4,13 @@
 Change Log
 ==========
 
+v3.8.0 (2026-08-XX)
+===================
+
+* Fixed `Model field completers can return completions that don't extend the typed text; integer completer hangs on "0" <https://github.com/django-commons/django-typer/issues/304>`_
+* Fixed `Get fish completion tests working <https://github.com/django-commons/django-typer/issues/180>`_
+    - Fish shellcompletion is now better supported.
+
 v3.7.4 (2026-07-31)
 ===================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,8 @@ test = [
     "maturin>=1.9.4; sys_platform == 'win32'",
     "pluggy>=1.5.0",
     "graphviz>=0.20.3",
-    "pexpect>=4.9.0"
+    "pexpect>=4.9.0",
+    "pyte>=0.8.2"
 ]
 dev = [
     { include-group = "typing" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-typer"
-version = "3.7.4"
+version = "3.8.0"
 requires-python = ">=3.10,<4.0"
 description = "Use Typer to define the CLI for your Django management commands."
 authors = [

--- a/src/django_typer/__init__.py
+++ b/src/django_typer/__init__.py
@@ -40,7 +40,7 @@ used directly to achieve this. We rely on robust CI to catch breaking changes up
 and keep a tight version lock on Typer.
 """
 
-VERSION = (3, 7, 4)
+VERSION = (3, 8, 0)
 
 __title__ = "Django Typer"
 __version__ = ".".join(str(i) for i in VERSION)

--- a/src/django_typer/completers/model.py
+++ b/src/django_typer/completers/model.py
@@ -16,6 +16,11 @@ def int_ranges(incomplete: str, max_val: int) -> list[tuple[int, int]]:
     lower = abs(lower)
     upper = abs(lower + 1)
     ranges = [(-upper, -lower)] if neg else [(lower, upper)]
+    if not lower:
+        # integers are never rendered with leading zeros, so 0 can only be
+        # completed by 0 itself (and appending digits below would never
+        # terminate)
+        return ranges
     while (lower := lower * 10) <= max_val:
         upper *= 10
         ranges.append((-upper, -lower) if neg else (lower, upper))
@@ -274,7 +279,7 @@ def duration_query(
     :raises AssertionError: If the incomplete string is not a valid partial
         duration.
     """
-    from django_typer.utils import parse_iso_duration
+    from django_typer.utils import duration_iso_string, parse_iso_duration
 
     duration, ambiguity = parse_iso_duration(incomplete)
     if incomplete.endswith("S") or (duration.microseconds and not ambiguity):
@@ -341,6 +346,14 @@ def duration_query(
                 )
             else:
                 # ambiguity is at least a seconds ambiguity
+                #
+                # completions are rendered with duration_iso_string, which
+                # elides zero components and never uses leading zeros -- so
+                # only continuations that canonical rendering can actually
+                # produce may be matched. A trailing 0 can only continue as
+                # a fractional seconds component (or PT0S for a total zero
+                # duration), and component values must be renderable
+                # (minutes <= 59, hours <= 23).
                 int_amb = int(ambiguity)
                 compound_horizon: list[
                     tuple[int, int]
@@ -351,40 +364,45 @@ def duration_query(
                         int_amb + 1,
                     )
                 )
-                compound_horizon.append(
-                    (int(f"{ambiguity}0"), min(int(f"{ambiguity}9") + 1, 60))
-                )
-                if "M" not in incomplete:
-                    # ambiguity is minutes or seconds
+                if int_amb:
                     compound_horizon.append(
-                        (
-                            int_amb * 60,
-                            int_amb * 60 + 60,
-                        )
+                        (int(f"{ambiguity}0"), min(int(f"{ambiguity}9") + 1, 60))
                     )
-                    if len(ambiguity) == 1:
+                    if "M" not in incomplete and int_amb <= 59:
+                        # ambiguity is minutes or seconds
                         compound_horizon.append(
                             (
-                                int(f"{ambiguity}0") * 60,
-                                min(int(f"{ambiguity}9") + 1, 60) * 60,
+                                int_amb * 60,
+                                int_amb * 60 + 60,
                             )
                         )
-                if "H" not in incomplete:
-                    # ambiguity is hours or minutes or seconds
-                    # bug here T1 could be T1H or T10H-T19H
-                    compound_horizon.append(
-                        (
-                            int_amb * 3600,
-                            int_amb * 3600 + 3600,
-                        )
-                    )
-                    if len(ambiguity) == 1:
+                        if len(ambiguity) == 1:
+                            compound_horizon.append(
+                                (
+                                    int(f"{ambiguity}0") * 60,
+                                    min(int(f"{ambiguity}9") + 1, 60) * 60,
+                                )
+                            )
+                    if (
+                        "H" not in incomplete
+                        and "M" not in incomplete
+                        and int_amb <= 23
+                    ):
+                        # ambiguity may also be hours, but only if a minutes
+                        # component has not already been given
                         compound_horizon.append(
                             (
-                                int(f"{ambiguity}0") * 3600,
-                                min(int(f"{ambiguity}9") + 1, 24) * 3600,
+                                int_amb * 3600,
+                                int_amb * 3600 + 3600,
                             )
                         )
+                        if len(ambiguity) == 1:
+                            compound_horizon.append(
+                                (
+                                    int(f"{ambiguity}0") * 3600,
+                                    min(int(f"{ambiguity}9") + 1, 24) * 3600,
+                                )
+                            )
                 c_qry = models.Q()
                 for lower, upper in compound_horizon:
                     lwr, upr = (
@@ -404,7 +422,12 @@ def duration_query(
                     c_qry |= h_qry
                 qry &= c_qry
 
-    inclusive = "" if incomplete.endswith("T") and duration.days else "e"
+    # the exact duration value is only a valid completion if its canonical
+    # rendering extends the incomplete string (e.g. PT0S extends PT0, but
+    # PT1H does not extend PT1H0 or PT1H0.)
+    inclusive = (
+        "e" if duration_iso_string(duration).startswith(incomplete.upper()) else ""
+    )
     qry &= (
         models.Q(**{f"{lookup_field}__lt{inclusive}": duration})
         if neg

--- a/src/django_typer/templates/shell_complete/fish.fish
+++ b/src/django_typer/templates/shell_complete/fish.fish
@@ -3,11 +3,11 @@ function __fish_{{prog_name}}_complete
     set cmd (commandline)
     set cursor (commandline -C)
 
-    set completeCmd {{ django_command }} --shell fish {{ color }} complete  {{ fallback }} "$cmd" "$cursor"
-
-    # We'll extract --settings=... and --pythonpath=... if present
-    set settingsOption ''
-    set pythonPathOption ''
+    # We'll extract --settings=... and --pythonpath=... if present so they can
+    # be forwarded to the shellcompletion command -- they may be necessary to
+    # find the command's INSTALLED_APPS, sys.path entries, etc.
+    set settingsOption
+    set pythonPathOption
 
     set match (string match -r -- '--settings(?:[ =])([^ ]+)' $cmd)
     if [ (count $match) -gt 0 ]
@@ -21,13 +21,10 @@ function __fish_{{prog_name}}_complete
         set pythonPathOption "--pythonpath=$pythonPathVal"
     end
 
-    # Only add these options if they're non-empty
-    if test -n "$settingsOption"
-        set completeCmd $completeCmd $settingsOption
-    end
-    if test -n "$pythonPathOption"
-        set completeCmd $completeCmd $pythonPathOption
-    end
+    # NB: --settings and --pythonpath are options of the shellcompletion
+    # command itself, NOT of its `complete` subcommand. They must appear
+    # BEFORE `complete` on the command line.
+    set completeCmd {{ django_command }} --shell fish $settingsOption $pythonPathOption {{ color }} complete {{ fallback }} "$cmd" "$cursor"
 
     set results (env TYPER_USE_RICH=0 {{ manage_script_name }} $completeCmd)
 

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -305,8 +305,13 @@ class _CompleteTestCase(with_typehint(TestCase)):
             self._write_shell(self.tabs)
 
             # TAB triggers an inline completion display -- no sentinel is
-            # possible, so wait for the output to settle.
-            output = _wait_for(self._read_shell, quiet_period=0.4, timeout=5.0)
+            # possible, so wait for the output to settle.  The quiet_period
+            # must be long enough to bridge the Django-bootstrap gap between
+            # the shell echoing our typed text and the completion subprocess
+            # actually producing output (the registered completer shells out
+            # to `django-admin shellcompletion complete`, which loads Django
+            # -- typically 1-2s on a cold interpreter).
+            output = _wait_for(self._read_shell, quiet_period=2.0, timeout=15.0)
         finally:
             self._invalidate_shell()
 

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -39,6 +39,24 @@ def scrub(output: str) -> str:
     )
 
 
+def render(output: str, cols: int = 80, rows: int = 200) -> str:
+    """Render terminal control sequences via pyte to recover visible screen text.
+
+    Why: bash's readline redisplay emits cursor-positioning codes interleaved
+    with literal characters and pad-spaces. Stripping CSI sequences leaves the
+    chars at the *wrong* positions (e.g. ``complet                  ion``),
+    so substring assertions against the resulting string fail even though the
+    user would see ``completion`` on their terminal. pyte replays the codes
+    against a virtual screen and gives us back what's actually visible.
+    """
+    import pyte
+
+    screen = pyte.Screen(cols, rows)
+    stream = pyte.Stream(screen)
+    stream.feed(output)
+    return "\n".join(line.rstrip() for line in screen.display).rstrip()
+
+
 _SENTINEL_PREFIX = "__DJT_SENTINEL_"
 
 
@@ -315,7 +333,7 @@ class _CompleteTestCase(with_typehint(TestCase)):
         finally:
             self._invalidate_shell()
 
-        return scrub(output) if scrub_output else output
+        return render(output) if scrub_output else output
 
     def run_app_completion(self):
         completions = self.get_completions(self.launch_script, "completion", " ")

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -30,30 +30,6 @@ except Exception:
     pass
 
 
-def read_all_from_fd_with_timeout(fd, timeout=3):
-    all_data = bytearray()
-    start_time = time.time()
-
-    while True:
-        # Calculate remaining time
-        remaining_time = timeout - (time.time() - start_time)
-        if remaining_time <= 0:
-            break  # Timeout reached
-
-        # Wait until the file descriptor is ready or the timeout is reached
-        rlist, _, _ = select.select([fd], [], [], remaining_time)
-        if not rlist:
-            break  # Timeout reached
-
-        # Read available data
-        data = os.read(fd, 1024)
-        if not data:
-            break  # End of file reached
-        all_data.extend(data)
-
-    return bytes(all_data).decode()
-
-
 def scrub(output: str) -> str:
     """Scrub control code characters and ansi escape sequences for terminal colors from output"""
     return (
@@ -61,6 +37,42 @@ def scrub(output: str) -> str:
         .replace("\t", "")
         .replace("\x08", "")
     )
+
+
+_SENTINEL_PREFIX = "__DJT_SENTINEL_"
+
+
+def _wait_for(
+    read_fn: t.Callable[[], str],
+    sentinel: t.Optional[str] = None,
+    quiet_period: float = 0.25,
+    timeout: float = 15.0,
+) -> str:
+    """
+    Poll ``read_fn`` until either:
+      * ``sentinel`` (if provided) has appeared and no new bytes arrived
+        for ``quiet_period`` seconds, OR
+      * no sentinel was given and no new bytes arrived for ``quiet_period``
+        seconds (pure quiescence wait).
+
+    Always bounded by ``timeout``. Returns the full buffer.
+    """
+    buf = ""
+    start = time.time()
+    last_data = time.time()
+    seen = sentinel is None
+    while time.time() - start < timeout:
+        data = read_fn()
+        if data:
+            buf += data
+            last_data = time.time()
+            if sentinel is not None and not seen and sentinel in buf:
+                seen = True
+        elif seen and (time.time() - last_data) >= quiet_period:
+            return buf
+        else:
+            time.sleep(0.02)
+    return buf
 
 
 class _CompleteTestCase(with_typehint(TestCase)):
@@ -74,6 +86,15 @@ class _CompleteTestCase(with_typehint(TestCase)):
 
     tabs: str
 
+    # Reset / clear-line key sequence sent between get_completions calls when
+    # reusing a long-running shell.  Ctrl+C works for pwsh / powershell / bash /
+    # zsh / fish (cancels the current edit line and re-prompts).
+    _reset_keys: str = "\x03"
+
+    # Per-instance shell process state (None when no shell is running).
+    _shell_state: t.Any = None
+    _sentinel_counter: int = 0
+
     @cached_property
     def command(self) -> ShellCompletion:
         cmd = get_command("shellcompletion", ShellCompletion)
@@ -86,12 +107,53 @@ class _CompleteTestCase(with_typehint(TestCase)):
         )
 
     def setUp(self):
+        self._shell_state = None
+        self._sentinel_counter = 0
         self.remove()
         super().setUp()
 
     def tearDown(self):
         self.remove()
+        self._invalidate_shell()
         super().tearDown()
+
+    def _next_sentinel(self) -> str:
+        self._sentinel_counter += 1
+        return f"{_SENTINEL_PREFIX}{self._sentinel_counter}__"
+
+    def _invalidate_shell(self) -> None:
+        """Tear down the long-running shell, if any.
+
+        Called whenever shell state (profile, registered completers) may
+        have changed and a fresh shell process is required.
+        """
+        state = self._shell_state
+        self._shell_state = None
+        if state is None:
+            return
+        if platform.system() == "Windows":
+            try:
+                state.close()
+            except Exception:
+                pass
+        else:
+            master_fd, slave_fd, process = state
+            # Close the fds first so the shell sees EOF on stdin and exits
+            # cleanly.  This avoids relying on SIGTERM, which some shells
+            # (notably interactive zsh) ignore.
+            for fd in (master_fd, slave_fd):
+                try:
+                    os.close(fd)
+                except Exception:
+                    pass
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                try:
+                    process.wait(timeout=2)
+                except Exception:
+                    pass
 
     def verify_install(self, script=None, directory: t.Optional[Path] = None):
         pass
@@ -120,6 +182,9 @@ class _CompleteTestCase(with_typehint(TestCase)):
             kwargs["fallback"] = fallback
         self.command.init(**init_kwargs)
         self.command.install(**kwargs)
+        # Profile / completer registration changed -- any running shell is
+        # stale.  Force the next get_completions to spawn fresh.
+        self._invalidate_shell()
         self.verify_install(script=script)
 
     def remove(self, script=None):
@@ -131,73 +196,89 @@ class _CompleteTestCase(with_typehint(TestCase)):
         if self.shell:
             self.command.init(shell=self.shell)
         self.command.uninstall(**kwargs)
+        self._invalidate_shell()
         self.get_completions("ping")  # just to reinit shell
         self.verify_remove(script=script)
 
+    # ------------------------------------------------------------------ #
+    # PTY plumbing
+    #
+    # The shell is spawned lazily on the first get_completions() call of a
+    # test and reused for subsequent calls in the same test.  install() /
+    # remove() / tearDown() invalidate it so the next call re-spawns with
+    # the updated user profile.  Fixed time.sleep() calls are replaced with
+    # sentinel-based waits (after each silent command we echo a unique
+    # marker and read until it appears, then drain to quiescence) and pure
+    # quiescence waits after TAB (where no sentinel is possible).
+    # ------------------------------------------------------------------ #
+
     if platform.system() == "Windows":
 
-        def get_completions(self, *cmds: str, scrub_output=True, position=0) -> str:
+        def _read_shell(self) -> str:
+            return self._shell_state.read() if self._shell_state is not None else ""
+
+        def _write_shell(self, data: str) -> None:
+            assert self._shell_state is not None
+            self._shell_state.write(data)
+
+        def _ensure_shell(self) -> None:
+            if self._shell_state is not None:
+                return
             import winpty
 
             assert self.shell
 
-            pty = winpty.PTY(256, 512)
-
-            def read_all() -> str:
-                output = ""
-                while data := pty.read():
-                    output += data
-                    time.sleep(0.1)
-                return output
-
-            # Start the subprocess
-            pty.spawn(
+            self._shell_state = winpty.PTY(256, 512)
+            self._shell_state.spawn(
                 self.shell, *([self.interactive_opt] if self.interactive_opt else [])
             )
 
-            # Wait for the shell to start and get to the prompt
-            time.sleep(3)
-            read_all()
+            # Wait for first prompt by echoing a sentinel; the shell will
+            # process it once the prompt is ready.
+            sentinel = self._next_sentinel()
+            self._write_shell(f"echo {sentinel}{os.linesep}")
+            _wait_for(self._read_shell, sentinel=sentinel, timeout=20.0)
 
             for line in self.environment:
-                pty.write(f"{line}{os.linesep}")
-
-            time.sleep(2)
-            output = read_all() + read_all()
-
-            pty.write(" ".join(cmds))
-            pty.write(position * ("\x1b[C" if position > 0 else "\x1b[D"))
-            time.sleep(0.1)
-            pty.write(self.tabs)
-
-            time.sleep(2)
-            completion = read_all() + read_all()
-
-            return scrub(completion) if scrub_output else completion
+                self._write_shell(f"{line}{os.linesep}")
+                sentinel = self._next_sentinel()
+                self._write_shell(f"echo {sentinel}{os.linesep}")
+                _wait_for(self._read_shell, sentinel=sentinel, timeout=15.0)
 
     else:
 
-        def get_completions(self, *cmds: str, scrub_output=True, position=0) -> str:
+        def _read_shell(self) -> str:
+            if self._shell_state is None:
+                return ""
+            master_fd = self._shell_state[0]
+            rlist, _, _ = select.select([master_fd], [], [], 0)
+            if not rlist:
+                return ""
+            try:
+                data = os.read(master_fd, 1024 * 1024)
+            except (BlockingIOError, OSError):
+                return ""
+            if not data:
+                return ""
+            return data.decode(errors="replace")
+
+        def _write_shell(self, data: str) -> None:
+            assert self._shell_state is not None
+            os.write(self._shell_state[0], data.encode())
+
+        def _ensure_shell(self) -> None:
+            if self._shell_state is not None:
+                return
             import fcntl
             import termios
             import pty
 
-            def read(fd):
-                """Function to read from a file descriptor."""
-                return os.read(fd, 1024 * 1024).decode()
-
-            # Create a pseudo-terminal
             master_fd, slave_fd = pty.openpty()
-
-            # Define window size - width and height
             os.set_blocking(slave_fd, False)
-            win_size = struct.pack("HHHH", 24, 80, 0, 0)  # 24 rows, 80 columns
+            os.set_blocking(master_fd, False)
+            win_size = struct.pack("HHHH", 24, 80, 0, 0)
             fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, win_size)
 
-            # env = os.environ.copy()
-            # env["TERM"] = "xterm-256color"
-
-            # Spawn a new shell process
             shell = self.shell or detect_shell()[0]
             process = subprocess.Popen(
                 [shell, *([self.interactive_opt] if self.interactive_opt else [])],
@@ -205,45 +286,42 @@ class _CompleteTestCase(with_typehint(TestCase)):
                 stdout=slave_fd,
                 stderr=slave_fd,
                 text=True,
-                # env=env,
-                # preexec_fn=os.setsid,
             )
-            # Wait for the shell to start and get to the prompt
-            print(read(master_fd))
+            self._shell_state = (master_fd, slave_fd, process)
+
+            sentinel = self._next_sentinel()
+            self._write_shell(f"echo {sentinel}{os.linesep}")
+            _wait_for(self._read_shell, sentinel=sentinel, timeout=15.0)
 
             for line in self.environment:
-                os.write(master_fd, f"{line}{os.linesep}".encode())
+                self._write_shell(f"{line}{os.linesep}")
+                sentinel = self._next_sentinel()
+                self._write_shell(f"echo {sentinel}{os.linesep}")
+                _wait_for(self._read_shell, sentinel=sentinel, timeout=10.0)
 
-            print(read(master_fd))
-            # Send a command with a tab character for completion
+    def get_completions(self, *cmds: str, scrub_output=True, position=0) -> str:
+        self._ensure_shell()
 
-            cmd = " ".join(cmds)
-            os.write(master_fd, cmd.encode())
+        # Drain anything left over from the previous call (e.g. a redrawn
+        # prompt after our reset keys) before we start typing.
+        _wait_for(self._read_shell, quiet_period=0.1, timeout=1.0)
 
-            # positioning does not seem to work :(
-            if position < 0:
-                os.write(master_fd, f"\033[{abs(position)}D".encode())
-            elif position > 0:
-                os.write(master_fd, f"\033[{abs(position)}C".encode())
-            time.sleep(0.5)
+        self._write_shell(" ".join(cmds))
+        if position > 0:
+            self._write_shell("\x1b[C" * position)
+        elif position < 0:
+            self._write_shell("\x1b[D" * abs(position))
+        self._write_shell(self.tabs)
 
-            print(f'"{cmd}"')
-            os.write(master_fd, self.tabs.encode())
+        # TAB triggers an inline completion display -- no sentinel is
+        # possible, so wait for the output to settle.
+        output = _wait_for(self._read_shell, quiet_period=0.4, timeout=5.0)
 
-            time.sleep(0.5)
+        # Reset the edit line so the next call starts from a clean prompt.
+        self._write_shell(self._reset_keys)
+        _wait_for(self._read_shell, quiet_period=0.15, timeout=2.0)
 
-            # Read the output
-            output = read_all_from_fd_with_timeout(master_fd)
-
-            # Clean up
-            os.close(slave_fd)
-            os.close(master_fd)
-            process.terminate()
-            process.wait()
-            # remove bell character which can show up in some terminals where we hit tab
-            if scrub_output:
-                return scrub(output)
-            return output
+        return scrub(output) if scrub_output else output
 
     def run_app_completion(self):
         completions = self.get_completions(self.launch_script, "completion", " ")

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -86,11 +86,6 @@ class _CompleteTestCase(with_typehint(TestCase)):
 
     tabs: str
 
-    # Reset / clear-line key sequence sent between get_completions calls when
-    # reusing a long-running shell.  Ctrl+C works for pwsh / powershell / bash /
-    # zsh / fish (cancels the current edit line and re-prompts).
-    _reset_keys: str = "\x03"
-
     # Per-instance shell process state (None when no shell is running).
     _shell_state: t.Any = None
     _sentinel_counter: int = 0
@@ -182,9 +177,6 @@ class _CompleteTestCase(with_typehint(TestCase)):
             kwargs["fallback"] = fallback
         self.command.init(**init_kwargs)
         self.command.install(**kwargs)
-        # Profile / completer registration changed -- any running shell is
-        # stale.  Force the next get_completions to spawn fresh.
-        self._invalidate_shell()
         self.verify_install(script=script)
 
     def remove(self, script=None):
@@ -196,20 +188,19 @@ class _CompleteTestCase(with_typehint(TestCase)):
         if self.shell:
             self.command.init(shell=self.shell)
         self.command.uninstall(**kwargs)
-        self._invalidate_shell()
         self.get_completions("ping")  # just to reinit shell
         self.verify_remove(script=script)
 
     # ------------------------------------------------------------------ #
     # PTY plumbing
     #
-    # The shell is spawned lazily on the first get_completions() call of a
-    # test and reused for subsequent calls in the same test.  install() /
-    # remove() / tearDown() invalidate it so the next call re-spawns with
-    # the updated user profile.  Fixed time.sleep() calls are replaced with
-    # sentinel-based waits (after each silent command we echo a unique
-    # marker and read until it appears, then drain to quiescence) and pure
-    # quiescence waits after TAB (where no sentinel is possible).
+    # Each get_completions() spawns a fresh shell, sources the environment,
+    # types the command + TAB, captures output, and tears the shell down.
+    # The previous implementation also spawned per-call but relied on fixed
+    # time.sleep() calls (3s for the first prompt + 2s after env + 2s after
+    # TAB).  Here those are replaced with sentinel-based waits (after each
+    # silent command we echo a unique marker and read until it appears) and
+    # pure quiescence waits after TAB (where no sentinel is possible).
     # ------------------------------------------------------------------ #
 
     if platform.system() == "Windows":
@@ -300,26 +291,24 @@ class _CompleteTestCase(with_typehint(TestCase)):
                 _wait_for(self._read_shell, sentinel=sentinel, timeout=10.0)
 
     def get_completions(self, *cmds: str, scrub_output=True, position=0) -> str:
+        # Ensure a clean shell for every call; previous test interactions
+        # (typed but un-Entered text, completion menus, prediction overlays)
+        # could otherwise contaminate the captured output.
+        self._invalidate_shell()
         self._ensure_shell()
+        try:
+            self._write_shell(" ".join(cmds))
+            if position > 0:
+                self._write_shell("\x1b[C" * position)
+            elif position < 0:
+                self._write_shell("\x1b[D" * abs(position))
+            self._write_shell(self.tabs)
 
-        # Drain anything left over from the previous call (e.g. a redrawn
-        # prompt after our reset keys) before we start typing.
-        _wait_for(self._read_shell, quiet_period=0.1, timeout=1.0)
-
-        self._write_shell(" ".join(cmds))
-        if position > 0:
-            self._write_shell("\x1b[C" * position)
-        elif position < 0:
-            self._write_shell("\x1b[D" * abs(position))
-        self._write_shell(self.tabs)
-
-        # TAB triggers an inline completion display -- no sentinel is
-        # possible, so wait for the output to settle.
-        output = _wait_for(self._read_shell, quiet_period=0.4, timeout=5.0)
-
-        # Reset the edit line so the next call starts from a clean prompt.
-        self._write_shell(self._reset_keys)
-        _wait_for(self._read_shell, quiet_period=0.15, timeout=2.0)
+            # TAB triggers an inline completion display -- no sentinel is
+            # possible, so wait for the output to settle.
+            output = _wait_for(self._read_shell, quiet_period=0.4, timeout=5.0)
+        finally:
+            self._invalidate_shell()
 
         return scrub(output) if scrub_output else output
 

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -39,7 +39,7 @@ def scrub(output: str) -> str:
     )
 
 
-def render(output: str, cols: int = 80, rows: int = 200) -> str:
+def render(output: str, cols: int = 500, rows: int = 200) -> str:
     """Render terminal control sequences via pyte to recover visible screen text.
 
     Why: bash's readline redisplay emits cursor-positioning codes interleaved
@@ -48,6 +48,13 @@ def render(output: str, cols: int = 80, rows: int = 200) -> str:
     so substring assertions against the resulting string fail even though the
     user would see ``completion`` on their terminal. pyte replays the codes
     against a virtual screen and gives us back what's actually visible.
+
+    The virtual screen is intentionally far wider than the PTY (which is 80
+    cols). Shells often wrap long input/output implicitly when the cursor
+    runs past the PTY's last column -- the byte stream contains no newline,
+    so a virtual screen matching the PTY would split the text. A wider
+    screen lets pyte keep the text on one row, matching the contiguous
+    substring we want to assert against (e.g. a long filesystem path).
     """
     import pyte
 

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -1,3 +1,4 @@
+import codecs
 import os
 import re
 import select
@@ -9,8 +10,6 @@ import typing as t
 from pathlib import Path
 import pytest
 from functools import cached_property
-import re
-import subprocess
 import platform
 from django.test import TestCase
 
@@ -28,15 +27,6 @@ try:
     default_shell = detect_shell()[0]
 except Exception:
     pass
-
-
-def scrub(output: str) -> str:
-    """Scrub control code characters and ansi escape sequences for terminal colors from output"""
-    return (
-        re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "", output, flags=re.IGNORECASE)
-        .replace("\t", "")
-        .replace("\x08", "")
-    )
 
 
 def flat_scrub(output: str) -> str:
@@ -187,6 +177,11 @@ class _CompleteTestCase(with_typehint(TestCase)):
     # Per-instance shell process state (None when no shell is running).
     _shell_state: t.Any = None
     _sentinel_counter: int = 0
+    # Incremental UTF-8 decoder (Unix path), recreated per shell spawn. A
+    # multi-byte UTF-8 sequence -- notably the 3-byte tab sentinel -- can
+    # straddle two os.read() chunks; a plain per-chunk decode would mangle
+    # it into replacement characters and the sentinel would never match.
+    _decoder: t.Any = None
 
     @cached_property
     def command(self) -> ShellCompletion:
@@ -215,7 +210,7 @@ class _CompleteTestCase(with_typehint(TestCase)):
         return f"{_SENTINEL_PREFIX}{self._sentinel_counter}__"
 
     def _invalidate_shell(self) -> None:
-        """Tear down the long-running shell, if any.
+        """Tear down the current shell process, if any.
 
         Called whenever shell state (profile, registered completers) may
         have changed and a fresh shell process is required.
@@ -225,10 +220,10 @@ class _CompleteTestCase(with_typehint(TestCase)):
         if state is None:
             return
         if platform.system() == "Windows":
-            try:
-                state.close()
-            except Exception:
-                pass
+            # winpty.PTY exposes no close()/terminate() API. Dropping the
+            # last reference frees the underlying console, which terminates
+            # the attached shell process.
+            del state
         else:
             master_fd, slave_fd, process = state
             # Close the fds first so the shell sees EOF on stdin and exits
@@ -286,7 +281,6 @@ class _CompleteTestCase(with_typehint(TestCase)):
         if self.shell:
             self.command.init(shell=self.shell)
         self.command.uninstall(**kwargs)
-        self.get_completions("ping")  # just to reinit shell
         self.verify_remove(script=script)
 
     # ------------------------------------------------------------------ #
@@ -349,7 +343,7 @@ class _CompleteTestCase(with_typehint(TestCase)):
                 return ""
             if not data:
                 return ""
-            return data.decode(errors="replace")
+            return self._decoder.decode(data)
 
         def _write_shell(self, data: str) -> None:
             assert self._shell_state is not None
@@ -362,6 +356,7 @@ class _CompleteTestCase(with_typehint(TestCase)):
             import termios
             import pty
 
+            self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
             master_fd, slave_fd = pty.openpty()
             os.set_blocking(slave_fd, False)
             os.set_blocking(master_fd, False)

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -385,6 +385,25 @@ class _CompleteTestCase(with_typehint(TestCase)):
             )
             self._shell_state = (master_fd, slave_fd, process)
 
+            # Wait for the shell's line editor (readline/zle) to take over
+            # the pty before typing anything. Until then the pty is in
+            # canonical mode and the KERNEL echoes writes straight back --
+            # which satisfies sentinel waits without the shell having
+            # processed (or even seen) the input. The line editor switching
+            # the terminal out of canonical mode is a positive readiness
+            # signal the tty driver cannot fake. Without this, everything
+            # below races shell startup and TAB can be consumed before
+            # completions are registered (first spawn on a cold CI runner,
+            # or any slow .zshrc).
+            deadline = time.time() + 15.0
+            while time.time() < deadline:
+                # drain startup output so the shell can't stall on a full
+                # pty buffer before it reaches its first prompt
+                self._read_shell()
+                if not termios.tcgetattr(slave_fd)[3] & termios.ICANON:
+                    break
+                time.sleep(0.01)
+
             sentinel = self._next_sentinel()
             self._write_shell(f"echo {sentinel}{os.linesep}")
             _wait_for(self._read_shell, sentinel=sentinel, timeout=15.0)

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -39,6 +39,34 @@ def scrub(output: str) -> str:
     )
 
 
+def flat_scrub(output: str) -> str:
+    """Strip ALL ANSI/escape sequences without simulating a terminal screen.
+
+    Use this instead of :func:`render` for shells whose completion display
+    is *ephemeral* -- i.e. characters drawn to the screen and then erased
+    by a follow-up control sequence (cursor-up + ``\\x1b[J`` erase-below
+    is the canonical pattern). Pyte faithfully replays such erasures and
+    loses the text, but for an assertion like ``assertIn("completers")``
+    we want to know what was *transmitted*, not what survived on a final
+    rendered screen.
+
+    Currently used by fish (the pager that displays multi-candidate
+    completion menus closes itself when extra input arrives and
+    overwrites its own region of the screen).
+    """
+    # CSI sequences (covers SGR colors, cursor moves, mode toggles,
+    # private/extended forms like \x1b[?2004h, \x1b[>4;1m, \x1b[=5u).
+    output = re.sub(r"\x1B\[[0-?]*[ -/]*[@-~]", "", output)
+    # OSC sequences (set window title etc.): ESC ] ... BEL | ST.
+    output = re.sub(r"\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)", "", output)
+    # Character set designation: ESC ( B, ESC ) 0, ESC * B, ESC + B.
+    output = re.sub(r"\x1B[\(\)*+][\dA-Z=]", "", output)
+    # Two-char escape forms: ESC =, ESC >, ESC 7, ESC 8.
+    output = re.sub(r"\x1B[=>78]", "", output)
+    # Stray control chars that aren't escape-introduced.
+    return output.replace("\x08", "").replace("\t", "").replace("\r", "")
+
+
 def render(output: str, cols: int = 500, rows: int = 200) -> str:
     """Render terminal control sequences via pyte to recover visible screen text.
 
@@ -120,6 +148,14 @@ class _CompleteTestCase(with_typehint(TestCase)):
     environment: t.List[str] = []
 
     tabs: str
+
+    # When True (Unix only), spawn the shell with os.setsid() + TIOCSCTTY so
+    # the child becomes session leader with a proper controlling terminal.
+    # Fish requires this -- it disables interactive features (including TAB
+    # completion) without a controlling TTY. zsh on the other hand REGRESSES
+    # under this setup -- ZLE / job-control init paths differ enough that
+    # our captured-output flow stops working. Bash is unaffected either way.
+    requires_controlling_terminal: bool = False
 
     # Per-instance shell process state (None when no shell is running).
     _shell_state: t.Any = None
@@ -305,6 +341,13 @@ class _CompleteTestCase(with_typehint(TestCase)):
             win_size = struct.pack("HHHH", 24, 80, 0, 0)
             fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, win_size)
 
+            def _become_session_leader() -> None:
+                # Give the child a proper controlling terminal. Fish refuses
+                # to run interactively without one (prints "warning: No TTY
+                # for interactive shell" and disables completion / readline).
+                os.setsid()
+                fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+
             shell = self.shell or detect_shell()[0]
             process = subprocess.Popen(
                 [shell, *([self.interactive_opt] if self.interactive_opt else [])],
@@ -312,6 +355,11 @@ class _CompleteTestCase(with_typehint(TestCase)):
                 stdout=slave_fd,
                 stderr=slave_fd,
                 text=True,
+                preexec_fn=(
+                    _become_session_leader
+                    if self.requires_controlling_terminal
+                    else None
+                ),
             )
             self._shell_state = (master_fd, slave_fd, process)
 
@@ -359,7 +407,18 @@ class _CompleteTestCase(with_typehint(TestCase)):
         # Strip the sentinel so callers never see this test artifact in
         # the rendered completion output.
         output = output.replace(_TAB_SENTINEL, "")
-        return render(output) if scrub_output else output
+        return self._render_output(output) if scrub_output else output
+
+    def _render_output(self, output: str) -> str:
+        """Convert raw PTY bytes to assertion-friendly text.
+
+        Default implementation uses :func:`render` (pyte-based) which
+        accurately reflects the *final* visible screen state. Shells whose
+        completion menus are drawn-then-overwritten (notably fish)
+        override this to use :func:`flat_scrub` so candidate text that
+        was transmitted but later erased remains in the result.
+        """
+        return render(output)
 
     def run_app_completion(self):
         completions = self.get_completions(self.launch_script, "completion", " ")

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -316,11 +316,17 @@ class _CompleteTestCase(with_typehint(TestCase)):
                 self.shell, *([self.interactive_opt] if self.interactive_opt else [])
             )
 
-            # Wait for first prompt by echoing a sentinel; the shell will
-            # process it once the prompt is ready.
-            sentinel = self._next_sentinel()
-            self._write_shell(f"echo {sentinel}{os.linesep}")
-            _wait_for(self._read_shell, sentinel=sentinel, timeout=20.0)
+            # Wait for the shell to PAINT its first prompt ("PS <cwd>>")
+            # before typing anything. An echoed sentinel is NOT a readiness
+            # signal here: until PowerShell takes over the console, conhost's
+            # cooked-mode echo reflects written input straight back,
+            # satisfying the wait while the shell is still initializing.
+            # Input typed during PSReadLine's console mode switch can then be
+            # split mid-line -- a half-submitted quoted env line leaves the
+            # shell in a ">>" continuation prompt that swallows everything
+            # typed after it. Nothing we write contains "PS ", so its
+            # appearance can only come from the shell itself.
+            _wait_for(self._read_shell, sentinel="PS ", quiet_period=0.5, timeout=30.0)
 
             for line in self.environment:
                 self._write_shell(f"{line}{os.linesep}")

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -101,13 +101,18 @@ _SENTINEL_PREFIX = "__DJT_SENTINEL_"
 # "completion is done" signal that avoids relying on a long
 # silence-based quiet_period.
 #
-# Must be a SINGLE-BYTE printable ASCII character. Multi-byte UTF-8
-# sentinels (e.g. ``‡`` = 0xe2 0x80 0xa1) break PSReadLine on
-# PowerShell -- it reads input byte-by-byte and treats high-bit bytes
-# as Meta-key prefixes (chord triggers), which flips the line into
-# continuation-prompt state ("\n>>") instead of cleanly appending.
-# Tilde is treated as a regular keystroke by all supported shells.
-_TAB_SENTINEL = "~"
+# Chosen as a multi-byte UTF-8 character that is exceedingly unlikely
+# to appear in any real completion candidate, in shell prompts, or in
+# terminal escape sequences (so it won't false-match in the captured
+# stream). Trade-off: PSReadLine reads input byte-by-byte and treats
+# the individual high-bit bytes (0xe2, 0x80, 0xa1 for ``‡``) as
+# Meta-key prefixes that flip the line into continuation-prompt state,
+# so PowerShell opts out of the sentinel path -- see ``tab_sentinel``.
+#
+# Single-byte ASCII alternatives (``~``, ``Q``, etc.) were tried but
+# either appear in shell prompts / escape sequences (false-match) or
+# in completion output (collision with .replace strip).
+_TAB_SENTINEL = "‡"
 
 
 def _wait_for(
@@ -161,6 +166,23 @@ class _CompleteTestCase(with_typehint(TestCase)):
     # under this setup -- ZLE / job-control init paths differ enough that
     # our captured-output flow stops working. Bash is unaffected either way.
     requires_controlling_terminal: bool = False
+
+    # When non-None, write this string immediately after TAB and wait for it
+    # to be echoed back as a positive "completion is done" signal. Shells
+    # process input serially, so the sentinel is guaranteed to be processed
+    # only AFTER the TAB-triggered completion finishes. Set to None to fall
+    # back to a pure quiet-period wait -- required for PowerShell, where
+    # PSReadLine interprets the multi-byte UTF-8 sentinel bytes (0xe2 0x80
+    # 0xa1 for ``‡``) as Meta-key chord input that puts the line into
+    # continuation-prompt state, breaking completion entirely.
+    tab_sentinel: t.Optional[str] = _TAB_SENTINEL
+
+    # Quiet period (seconds of silence) used when ``tab_sentinel`` is None.
+    # Must be long enough to bridge the Django-bootstrap gap between echoing
+    # the typed text and the completion subprocess actually producing
+    # output. On slow CI VMs (especially Windows) cold-start Django can
+    # take 3-4s, so we default to a generous value.
+    tab_quiet_period: float = 4.0
 
     # Per-instance shell process state (None when no shell is running).
     _shell_state: t.Any = None
@@ -391,27 +413,37 @@ class _CompleteTestCase(with_typehint(TestCase)):
             elif position < 0:
                 self._write_shell("\x1b[D" * abs(position))
             self._write_shell(self.tabs)
-            # Sentinel-after-TAB: shells process input serially, so this
-            # character can only be echoed back AFTER TAB-triggered
-            # completion has fully finished (including the Django
-            # subprocess call that powers our completer). Waiting for
-            # the sentinel in the captured stream is much faster and
-            # more reliable than waiting for a quiet period long enough
-            # to cover slow CI Django boots.
-            self._write_shell(_TAB_SENTINEL)
-
-            output = _wait_for(
-                self._read_shell,
-                sentinel=_TAB_SENTINEL,
-                quiet_period=0.3,
-                timeout=25.0,
-            )
+            if self.tab_sentinel is not None:
+                # Sentinel-after-TAB: shells process input serially, so
+                # this character can only be echoed back AFTER TAB-
+                # triggered completion has fully finished (including the
+                # Django subprocess call that powers our completer).
+                # Waiting for the sentinel in the captured stream is
+                # much faster and more reliable than waiting for a quiet
+                # period long enough to cover slow CI Django boots.
+                self._write_shell(self.tab_sentinel)
+                output = _wait_for(
+                    self._read_shell,
+                    sentinel=self.tab_sentinel,
+                    quiet_period=0.3,
+                    timeout=25.0,
+                )
+            else:
+                # Sentinel-less path: fall back to pure quiet-period
+                # detection. Required for PowerShell -- see comment on
+                # ``tab_sentinel``.
+                output = _wait_for(
+                    self._read_shell,
+                    quiet_period=self.tab_quiet_period,
+                    timeout=25.0,
+                )
         finally:
             self._invalidate_shell()
 
-        # Strip the sentinel so callers never see this test artifact in
-        # the rendered completion output.
-        output = output.replace(_TAB_SENTINEL, "")
+        # Strip the sentinel (no-op for sentinel-less shells) so callers
+        # never see this test artifact in the rendered completion output.
+        if self.tab_sentinel is not None:
+            output = output.replace(self.tab_sentinel, "")
         return self._render_output(output) if scrub_output else output
 
     def _render_output(self, output: str) -> str:

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -737,17 +737,17 @@ class _InstalledScriptCompleteTestCase(_CompleteTestCase):
             **env,
         }
 
-        rex = re.compile
+        # NB: these must be pattern STRINGS, not pre-compiled patterns. pexpect
+        # compiles string patterns itself with re.DOTALL (needed so
+        # (?P<file>.*) can span the line folds rich inserts into long paths on
+        # narrow terminals). Pre-compiled str patterns handed to a bytes-mode
+        # spawn get recompiled by pexpect's _coerce_expect_re WITHOUT their
+        # flags -- silently dropping DOTALL and timing out on folded prompts.
         expected = [
-            rex(
-                r"Append\s+the\s+above\s+contents\s+to\s+(?P<file>.*)\?", re.DOTALL
-            ),  # 0
-            rex(
-                r"Create\s+(?P<file>.*)\s+with\s+the\s+above\s+contents\?",
-                re.DOTALL,
-            ),  # 1
-            rex(r"Aborted\s+shell\s+completion\s+installation."),  # 2
-            rex(rf"Installed\s+autocompletion\s+for\s+{self.shell}"),  # 3
+            r"Append\s+the\s+above\s+contents\s+to\s+(?P<file>.*)\?",  # 0
+            r"Create\s+(?P<file>.*)\s+with\s+the\s+above\s+contents\?",  # 1
+            r"Aborted\s+shell\s+completion\s+installation\.",  # 2
+            rf"Installed\s+autocompletion\s+for\s+{self.shell}",  # 3
         ]
 
         install_command = [
@@ -761,8 +761,12 @@ class _InstalledScriptCompleteTestCase(_CompleteTestCase):
         self.verify_remove(directory=directory)
 
         if platform.system() != "Windows":
-            install = pexpect.spawn(self.manage_script, install_command, env=env)
-            install.setwinsize(24, 800)
+            # dimensions must be given at spawn -- a setwinsize() call after
+            # spawn races the child's first read of the terminal size, and a
+            # child that reads the 80-col default wraps long prompt paths
+            install = pexpect.spawn(
+                self.manage_script, install_command, env=env, dimensions=(24, 800)
+            )
         else:
             from pexpect.popen_spawn import PopenSpawn
 
@@ -795,8 +799,9 @@ class _InstalledScriptCompleteTestCase(_CompleteTestCase):
 
         # test an install
         if platform.system() != "Windows":
-            install = pexpect.spawn(self.manage_script, install_command, env=env)
-            install.setwinsize(24, 800)
+            install = pexpect.spawn(
+                self.manage_script, install_command, env=env, dimensions=(24, 800)
+            )
         else:
             from pexpect.popen_spawn import PopenSpawn
 

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -66,6 +66,16 @@ def render(output: str, cols: int = 500, rows: int = 200) -> str:
 
 _SENTINEL_PREFIX = "__DJT_SENTINEL_"
 
+# Sentinel byte written immediately after TAB. Because shell input is
+# processed serially, this character can only be echoed back AFTER the
+# shell has finished the TAB-triggered completion (subprocess call +
+# line rewrite). Spotting it in the captured stream is a positive
+# "completion is done" signal that avoids relying on a long
+# silence-based quiet_period. Chosen to be a printable char that no
+# shell treats as a control action AND that is exceedingly unlikely to
+# appear in any real Django completion candidate.
+_TAB_SENTINEL = "‡"  # double dagger: ‡
+
 
 def _wait_for(
     read_fn: t.Callable[[], str],
@@ -328,18 +338,27 @@ class _CompleteTestCase(with_typehint(TestCase)):
             elif position < 0:
                 self._write_shell("\x1b[D" * abs(position))
             self._write_shell(self.tabs)
+            # Sentinel-after-TAB: shells process input serially, so this
+            # character can only be echoed back AFTER TAB-triggered
+            # completion has fully finished (including the Django
+            # subprocess call that powers our completer). Waiting for
+            # the sentinel in the captured stream is much faster and
+            # more reliable than waiting for a quiet period long enough
+            # to cover slow CI Django boots.
+            self._write_shell(_TAB_SENTINEL)
 
-            # TAB triggers an inline completion display -- no sentinel is
-            # possible, so wait for the output to settle.  The quiet_period
-            # must be long enough to bridge the Django-bootstrap gap between
-            # the shell echoing our typed text and the completion subprocess
-            # actually producing output (the registered completer shells out
-            # to `django-admin shellcompletion complete`, which loads Django
-            # -- typically 1-2s on a cold interpreter).
-            output = _wait_for(self._read_shell, quiet_period=2.0, timeout=15.0)
+            output = _wait_for(
+                self._read_shell,
+                sentinel=_TAB_SENTINEL,
+                quiet_period=0.3,
+                timeout=25.0,
+            )
         finally:
             self._invalidate_shell()
 
+        # Strip the sentinel so callers never see this test artifact in
+        # the rendered completion output.
+        output = output.replace(_TAB_SENTINEL, "")
         return render(output) if scrub_output else output
 
     def run_app_completion(self):

--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -99,10 +99,15 @@ _SENTINEL_PREFIX = "__DJT_SENTINEL_"
 # shell has finished the TAB-triggered completion (subprocess call +
 # line rewrite). Spotting it in the captured stream is a positive
 # "completion is done" signal that avoids relying on a long
-# silence-based quiet_period. Chosen to be a printable char that no
-# shell treats as a control action AND that is exceedingly unlikely to
-# appear in any real Django completion candidate.
-_TAB_SENTINEL = "‡"  # double dagger: ‡
+# silence-based quiet_period.
+#
+# Must be a SINGLE-BYTE printable ASCII character. Multi-byte UTF-8
+# sentinels (e.g. ``‡`` = 0xe2 0x80 0xa1) break PSReadLine on
+# PowerShell -- it reads input byte-by-byte and treats high-bit bytes
+# as Meta-key prefixes (chord triggers), which flips the line into
+# continuation-prompt state ("\n>>") instead of cleanly appending.
+# Tilde is treated as a regular keystroke by all supported shells.
+_TAB_SENTINEL = "~"
 
 
 def _wait_for(

--- a/tests/shellcompletion/test_fish.py
+++ b/tests/shellcompletion/test_fish.py
@@ -10,6 +10,7 @@ from django.core.management import CommandError
 from tests.shellcompletion import (
     _ScriptCompleteTestCase,
     _InstalledScriptCompleteTestCase,
+    flat_scrub,
 )
 
 
@@ -19,11 +20,23 @@ class _FishMixin:
     tabs = "\t"
     directory = Path("~/.config/fish/completions").expanduser()
     interactive_opt = "--interactive"
+    # Fish disables interactive features (incl. completion) without a
+    # proper controlling TTY -- it prints "warning: No TTY for interactive
+    # shell (tcgetpgrp failed)" and degrades into a non-interactive mode.
+    requires_controlling_terminal = True
 
     environment = [
         f"set -x DJANGO_SETTINGS_MODULE 'tests.settings.completion'",
         f"source {Path(sys.executable).absolute().parent / 'activate.fish'}",
     ]
+
+    def _render_output(self, output: str) -> str:
+        # Fish's pager draws candidate menus and then erases them with
+        # cursor-up + \x1b[J before redrawing the prompt. pyte's screen
+        # simulation loses the candidates because they've been erased on
+        # screen. flat_scrub keeps the transmitted bytes so we can assert
+        # against what fish actually emitted.
+        return flat_scrub(output)
 
     def verify_install(self, script=None, directory: t.Optional[Path] = None):
         directory = directory or self.directory
@@ -76,37 +89,6 @@ class FishExeShellTests(_FishMixin, _InstalledScriptCompleteTestCase, TestCase):
     @pytest.mark.skip(reason="fish does not support ansi control sequences")
     def test_rich_output(self): ...
 
-    # TODO - fix fish tests, having trouble running it in a subprocess!!
-    def test_shell_complete(self):
-        self.remove()
-        self.verify_remove()
-        self.remove()
-        self.verify_remove()
-        self.install()
-        self.verify_install()
-        self.install()
-        self.verify_install()
-        self.remove()
-        self.verify_remove()
-
     @pytest.mark.rich
-    @pytest.mark.skip(reason="TODO")
+    @pytest.mark.skip(reason="fish does not support ansi control sequences")
     def test_no_rich_output(self): ...
-
-    @pytest.mark.skip(reason="TODO")
-    def test_settings_pass_through(self): ...
-
-    @pytest.mark.skip(reason="TODO")
-    def test_pythonpath_pass_through(self): ...
-
-    @pytest.mark.skip(reason="TODO")
-    def test_fallback(self): ...
-
-    @pytest.mark.skip(reason="TODO")
-    def test_reentrant_install_uninstall(self): ...
-
-    @pytest.mark.skip(reason="TODO")
-    def test_multi_install(self): ...
-
-    @pytest.mark.skip(reason="TODO")
-    def test_path_completion(self): ...

--- a/tests/shellcompletion/test_powershell.py
+++ b/tests/shellcompletion/test_powershell.py
@@ -23,6 +23,12 @@ class _PowerShellMixin:
     profile: Path
     tabs = "\t"
     completer_class = PowerShellComplete
+    # PSReadLine reads input byte-by-byte and treats the high-bit bytes
+    # of the default multi-byte sentinel (0xe2 0x80 0xa1 for ``‡``) as
+    # Meta-key chord input, which flips the line into multi-line
+    # continuation state ("\n>>") and breaks completion. Fall back to
+    # pure quiet-period detection.
+    tab_sentinel = None
 
     environment = [
         f"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",

--- a/tests/shellcompletion/test_zsh.py
+++ b/tests/shellcompletion/test_zsh.py
@@ -1,3 +1,4 @@
+import glob
 import shutil
 from pathlib import Path
 import typing as t
@@ -25,6 +26,22 @@ class ZshTests(_ScriptCompleteTestCase, TestCase):
         f"PATH={Path(sys.executable).parent}:$PATH",
         f"DJANGO_SETTINGS_MODULE=tests.settings.completion",
     ]
+
+    def setUp(self):
+        # Force a fresh compinit on every shell spawn. A stale
+        # ~/.zcompdump (which persists across test methods on macOS CI
+        # runners, where a single $HOME is shared for the whole job)
+        # can cause a newly-installed completion function -- e.g. the
+        # one rewritten by test_fallback with a --fallback arg -- to
+        # be missed entirely on the first TAB. Costs ~200-500ms per
+        # test for the full compinit security check, no risk of
+        # regressing other tests.
+        for f in glob.glob(str(Path.home() / ".zcompdump*")):
+            try:
+                os.unlink(f)
+            except OSError:
+                pass
+        super().setUp()
 
     def verify_install(self, script=None, directory: t.Optional[Path] = None):
         directory = directory or self.directory

--- a/tests/test_parser_completers.py
+++ b/tests/test_parser_completers.py
@@ -204,6 +204,17 @@ class TestShellCompletersAndParsers(ParserCompleterMixin, TestCase):
             timedelta(minutes=1),
             timedelta(hours=1),
             timedelta(days=1),
+            # deterministic regressions for the ambiguous-digit completion
+            # windows in duration_query. Canonical iso strings elide zero
+            # components and never use leading zeros, so none of these may
+            # complete PT0 (except PT0S), PT1H0, PT5M1 or PT40:
+            timedelta(seconds=587, microseconds=603183),  # PT9M47.603183S
+            timedelta(minutes=19, seconds=47, microseconds=603183),  # PT19M47.603183S
+            timedelta(hours=1, microseconds=500000),  # PT1H0.500000S
+            timedelta(minutes=5, seconds=1),  # PT5M1S
+            timedelta(hours=1, minutes=5, seconds=30),  # PT1H5M30S
+            timedelta(minutes=40, seconds=5),  # PT40M5S
+            timedelta(hours=40, minutes=30),  # P1DT16H30M
             # we add some random values. neat little trick to explore more edge
             # cases each time the tests are run! - make sure hard coded tests
             # 100% coverage
@@ -1442,6 +1453,18 @@ class TestShellCompletersAndParsers(ParserCompleterMixin, TestCase):
                 json.loads(call_command("model_fields", "test", "--id", str(id))),
                 {"id": id},
             )
+
+        # integers are never rendered with leading zeros, so a lone 0 can
+        # only match an exact 0 value (regression: this used to infinite
+        # loop in int_ranges)
+        result = call_command(
+            "shellcompletion",
+            "--shell",
+            SHELL,
+            "complete",
+            "model_fields test --id 0",
+        )
+        self.assertEqual(list(get_values(result)), [])
 
         # test the limit option
         result = call_command(


### PR DESCRIPTION
Refactor shellcompletion tests so they don't rely on waits.

closes #180
closes #304 