### PR TITLE
fix windows legacy powershell tab completion race

### DIFF
--- a/tests/shellcompletion/__init__.py
+++ b/tests/shellcompletion/__init__.py
@@ -420,51 +420,64 @@ class _CompleteTestCase(with_typehint(TestCase)):
                 self._write_shell(f"echo {sentinel}{os.linesep}")
                 _wait_for(self._read_shell, sentinel=sentinel, timeout=10.0)
 
-    def get_completions(self, *cmds: str, scrub_output=True, position=0) -> str:
-        # Ensure a clean shell for every call; previous test interactions
-        # (typed but un-Entered text, completion menus, prediction overlays)
-        # could otherwise contaminate the captured output.
-        self._invalidate_shell()
-        self._ensure_shell()
-        try:
-            self._write_shell(" ".join(cmds))
-            if position > 0:
-                self._write_shell("\x1b[C" * position)
-            elif position < 0:
-                self._write_shell("\x1b[D" * abs(position))
-            self._write_shell(self.tabs)
-            if self.tab_sentinel is not None:
-                # Sentinel-after-TAB: shells process input serially, so
-                # this character can only be echoed back AFTER TAB-
-                # triggered completion has fully finished (including the
-                # Django subprocess call that powers our completer).
-                # Waiting for the sentinel in the captured stream is
-                # much faster and more reliable than waiting for a quiet
-                # period long enough to cover slow CI Django boots.
-                self._write_shell(self.tab_sentinel)
-                output = _wait_for(
-                    self._read_shell,
-                    sentinel=self.tab_sentinel,
-                    quiet_period=0.3,
-                    timeout=25.0,
-                )
-            else:
-                # Sentinel-less path: fall back to pure quiet-period
-                # detection. Required for PowerShell -- see comment on
-                # ``tab_sentinel``.
-                output = _wait_for(
-                    self._read_shell,
-                    quiet_period=self.tab_quiet_period,
-                    timeout=25.0,
-                )
-        finally:
-            self._invalidate_shell()
+    # Number of attempts (each against a freshly spawned shell) a
+    # get_completions() call makes when :meth:`_bad_capture` flags the
+    # captured output as a known-bad interactive state.
+    completion_attempts: int = 3
 
-        # Strip the sentinel (no-op for sentinel-less shells) so callers
-        # never see this test artifact in the rendered completion output.
-        if self.tab_sentinel is not None:
-            output = output.replace(self.tab_sentinel, "")
+    def get_completions(self, *cmds: str, scrub_output=True, position=0) -> str:
+        for attempt in range(self.completion_attempts):
+            # Ensure a clean shell for every call; previous test interactions
+            # (typed but un-Entered text, completion menus, prediction
+            # overlays) could otherwise contaminate the captured output.
+            self._invalidate_shell()
+            self._ensure_shell()
+            try:
+                self._write_shell(" ".join(cmds))
+                if position > 0:
+                    self._write_shell("\x1b[C" * position)
+                elif position < 0:
+                    self._write_shell("\x1b[D" * abs(position))
+                self._write_shell(self.tabs)
+                if self.tab_sentinel is not None:
+                    # Sentinel-after-TAB: shells process input serially, so
+                    # this character can only be echoed back AFTER TAB-
+                    # triggered completion has fully finished (including the
+                    # Django subprocess call that powers our completer).
+                    # Waiting for the sentinel in the captured stream is
+                    # much faster and more reliable than waiting for a quiet
+                    # period long enough to cover slow CI Django boots.
+                    self._write_shell(self.tab_sentinel)
+                    output = _wait_for(
+                        self._read_shell,
+                        sentinel=self.tab_sentinel,
+                        quiet_period=0.3,
+                        timeout=25.0,
+                    )
+                else:
+                    # Sentinel-less path: fall back to pure quiet-period
+                    # detection. Required for PowerShell -- see comment on
+                    # ``tab_sentinel``.
+                    output = _wait_for(
+                        self._read_shell,
+                        quiet_period=self.tab_quiet_period,
+                        timeout=25.0,
+                    )
+            finally:
+                self._invalidate_shell()
+
+            # Strip the sentinel (no-op for sentinel-less shells) so callers
+            # never see this test artifact in the rendered completion output.
+            if self.tab_sentinel is not None:
+                output = output.replace(self.tab_sentinel, "")
+            if not self._bad_capture(output):
+                break
         return self._render_output(output) if scrub_output else output
+
+    def _bad_capture(self, output: str) -> bool:
+        """Return True if the capture shows a known-bad interactive state
+        that warrants a retry with a fresh shell (see PowerShell override)."""
+        return False
 
     def _render_output(self, output: str) -> str:
         """Convert raw PTY bytes to assertion-friendly text.

--- a/tests/shellcompletion/test_powershell.py
+++ b/tests/shellcompletion/test_powershell.py
@@ -15,6 +15,7 @@ from django_typer.shells.powershell import (
 from tests.shellcompletion import (
     _ScriptCompleteTestCase,
     _InstalledScriptCompleteTestCase,
+    render,
 )
 
 
@@ -29,6 +30,21 @@ class _PowerShellMixin:
     # continuation state ("\n>>") and breaks completion. Fall back to
     # pure quiet-period detection.
     tab_sentinel = None
+    # The completion path on Windows CI (PSReadLine tab handler -> our
+    # scriptblock -> cold Django subprocess) can stay silent for several
+    # seconds before producing output; a short quiet period returns with a
+    # pre-completion screen.
+    tab_quiet_period = 6.0
+
+    def _bad_capture(self, output: str) -> bool:
+        # PSReadLine under ConPTY intermittently drops the input line into
+        # multi-line continuation state -- the capture ends with a ">>"
+        # continuation prompt and the typed line was never completed. This
+        # is a long-standing environment flake (identical signatures appear
+        # in CI logs across unrelated tests and harness implementations
+        # since at least June 2026). The state cannot be recovered
+        # in-session; retry against a fresh shell.
+        return render(output).rstrip().endswith(">>")
 
     environment = [
         f"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",


### PR DESCRIPTION
The main strategy behind the fix is to catch the race and retry - up to three times.